### PR TITLE
Die Rise Maxis TS Modification for 3p (#6)

### DIFF
--- a/Patches/buried_any_player_ee-body_fix.gsc
+++ b/Patches/buried_any_player_ee-body_fix.gsc
@@ -63,7 +63,7 @@ _are_all_players_in_time_bomb_volume_qol( e_volume )
 	if ( getPlayers().size <= 3 )
 		n_required_players = a_players.size;
 /#
-	if ( getdvarint( #"5256118F" ) > 0 )
+	if ( getdvarint( #"_id_5256118F" ) > 0 )
 		n_required_players = a_players.size;
 #/
 	n_players_in_position = 0;

--- a/Patches/die_rise_any_player_ee-no_reset.gsc
+++ b/Patches/die_rise_any_player_ee-no_reset.gsc
@@ -141,7 +141,8 @@ custom_drg_puzzle_trig_think( n_order_id )
 #/
 			self thread drg_puzzle_trig_watch_fade( m_lit, m_unlit, v_top, v_hidden );
 		}
-/*		else
+/*
+		else
 		{
 			if ( !flag( "sq_atd_drg_puzzle_1st_error" ) )
 				level thread vo_maxis_atd_order_error();
@@ -154,6 +155,7 @@ custom_drg_puzzle_trig_think( n_order_id )
 			wait 0.5;
 		}
 */
+
 		while ( e_who istouching( self ) )
 			wait 0.5;
 	}
@@ -171,7 +173,7 @@ custom_get_number_of_players()
 
 // Trample Steam steps
 
-//if the number of players is less than or equal to 2 and a ball is placed for the Maxis Trample Steam step, keeps the trigger to place a new ball for the Trample Steam it was placed on and the one opposite from it
+//if the number of players is less than or equal to 3 and a ball is placed for the Maxis Trample Steam step, keeps the trigger to place a new ball for the Trample Steam it was placed on and the one opposite from it
 //if the number of players is 3, creates trigs for each player already carrying a ball to enable them to place the ball on the lone Trample Steam if the Trample Steam was correctly placed before the 1st ball is launched.
 custom_place_ball_think( t_place_ball, s_lion_spot )
 {
@@ -180,7 +182,7 @@ custom_place_ball_think( t_place_ball, s_lion_spot )
 	t_place_ball waittill( "trigger" );
 
 	a_players = getPlayers();
-	if ( a_players.size > 2 )
+	if ( a_players.size > 3 )
 	{
 		pts_putdown_trigs_remove_for_spot( s_lion_spot );
 		pts_putdown_trigs_remove_for_spot( s_lion_spot.springpad_buddy );
@@ -253,10 +255,10 @@ custom_pts_should_springpad_create_trigs( s_lion_spot )
 	}
 }
 
-//if the number of players is 2 or less, once a ball is picked up, gives the ability to place a 2nd ball on a set of Trample Steams that already has a ball flinging from them for the Maxis Trample Steam step
+//if the number of players is 3 or less, once a ball is picked up, gives the ability to place a 2nd ball on a set of Trample Steams that already has a ball flinging from them for the Maxis Trample Steam step
 custom_pts_putdown_trigs_create_for_spot( s_lion_spot, player )
 {
-	if ( ( isdefined( s_lion_spot.which_ball ) || isdefined( s_lion_spot.springpad_buddy ) && isdefined( s_lion_spot.springpad_buddy.which_ball ) ) && getPlayers().size > 2 )
+	if ( ( isdefined( s_lion_spot.which_ball ) || isdefined( s_lion_spot.springpad_buddy ) && isdefined( s_lion_spot.springpad_buddy.which_ball ) ) && getPlayers().size > 3 )
 		return;
 
 	t_place_ball = sq_pts_create_use_trigger( s_lion_spot.origin, 16, 70, &"ZM_HIGHRISE_SQ_PUTDOWN_BALL" );

--- a/README.md
+++ b/README.md
@@ -1,38 +1,50 @@
 # Plutonium-T6-Any-Player-EE-Scripts-For-Speedrunning
+The following scripts allow the main Easter Egg quests to be done with any number of players—whether it is solo (1 player), duo (2 players), trio (3 players), or even more than 4 players—while aiming to be as similar to the original Easter Eggs as possible.
 ## Installation
 1. Navigate to the [Releases](https://github.com/Hadi77KSA/Plutonium-T6-Any-Player-EE-Scripts-For-Speedrunning/releases/latest) page and download the script you desire.
 2. Navigate to `%localappdata%\Plutonium\storage\t6\scripts\zm`
 3. Place the files into their respective map's folder. If the map's folder doesn't exist, create it and place it into the path from step 2.
-- `die_rise_any_player_ee.gsc` goes to `zm_highrise`
-- `buried_any_player_ee.gsc` goes to `zm_buried`
+- TranZit's scripts go to `zm_transit`
+- Die Rise's scripts go to `zm_highrise`
+- Buried's scripts go to `zm_buried`
 - `super_ee_any_player.gsc` goes to `zm_buried`
 
+# Features
+## TranZit
+Uses CCDeroga's mod to allow the Maxis side to be completable in solo.  
+Note that it does not show a message in-game indicating it is loaded once the map is started. To determine if it has been loaded successfully, either go through the Easter Egg and perform a step and listen out for the quotes, or check the Plutonium bootstrapper window for if it says the following line when the map is started:
+```
+Script "scripts/zm/zm_transit/tranzit_maxis_solo.gsc" loaded successfully
+```
+### - Tower Step and Lamp Post Step for the Maxis Side
+Only require 1 Turbine if the match was started as a solo match.
+
 ## Die Rise
+### - Elevators Step and Dragon Puzzle
+Require the same amount as the number of players.  
+If the Dragon Puzzle step is failed, it will reset back to require the same amount as the number of players.
 
-### Elevators Step and Dragon Puzzle
-Require the same amount as the number of players. If the Dragon Puzzle step is failed, it will reset back to require the same amount as the number of players.
-
-### Trample Steam step:
-#### Maxis Side
-- On solo and on 3p while the 1st ball is already flinging between Trample Steams placed on a set lion symbols, only one Trample Steam will be required in order to be able to place down a ball.
-- If the number of players is 2 or less, the players will have the ability to place both balls on the same set of Trample Steams.
+### - Trample Steam Step
+#### a) Maxis Side
+- On solo and on 3p while the 1st ball is already flinging between Trample Steams placed on a set of lion symbols, only one Trample Steam will be required in order to be able to place down a ball.
+- If the number of players is 3 or less, the players will have the ability to place both balls on the same set of Trample Steams.
 - On 3p, having the 1st ball flinging is required to be able to place the other ball on the lone Trample Steam.
 
-#### Richtofen Side
+#### b) Richtofen Side
 Requires the players to place Trample Steams only on the same amount of symbols as players.
 
 ## Buried
-### Maxis Side
-Only works for less than 3p.
-#### Wisp Step
-Wisp no longer relies on zombies getting near it.
+### a) Maxis Side
+#### - Wisp Step
+For less than 3p, wisp will no longer rely on zombies getting near it.
 
-#### Bells Step
-Removed time limit. Only resets if it's failed.
+#### - Bells Step
+For less than 3p, time limit will be removed. Will only reset if it is failed.
 
-### Richtofen Side
-#### Round Infinity A.K.A the Time Bomb Step
-Can be done with less than 4 players. Requires all players in the lobby to be near the location of the Time Bomb.
+### b) Richtofen Side
+#### - Round Infinity A.K.A the Time Bomb Step
+On 4p or less, requires all players in the lobby to be near the location of the Time Bomb.  
+If the number of players is greater than 4, the step will only work if 4 players are near the location, no more no less, exactly how it works without the mod.
 
 ### Sharpshooter
 Minimum number of required targets:
@@ -41,4 +53,48 @@ Minimum number of required targets:
 - Otherwise: all 84 targets
 
 ## Super Easter Egg
-Allows for the Super Easter Egg button to be accessible with any number of players as long as: the players have, collectively, inserted the Navcards on all three Victis maps of TranZit, Die Rise, and Buried; and each player in the lobby has completed the Victis maps' Easter Eggs on the same side across the maps; and the completed side across all players is the same.
+Allows for the Super Easter Egg button to be accessible with any number of players as long as:
+- the players have, collectively, inserted the Navcards on all three Victis maps of TranZit, Die Rise, and Buried;
+- each player in the lobby has completed the Victis maps' Easter Eggs on the same side across the maps;
+- the completed side across all players is the same.
+
+For more than 4 players, the mod will only use the player progress that is shown on the box.
+
+# FAQ
+## - Q: Do I/we need all of these mods to do all the Victis EEs?
+A: Depends on the number of players and which maps and side you choose. The host is required to have the mods installed. The following shows the required files:
+  - 1p:-
+    - TranZit Maxis:
+      - `tranzit_maxis_solo.gsc`
+    - Die Rise: `die_rise_any_player_ee.gsc`
+    - Buried: `buried_any_player_ee.gsc`
+    - Super EE: `super_ee_any_player.gsc`
+  - 2p:-
+    - Die Rise: `die_rise_any_player_ee.gsc`
+    - Buried: `buried_any_player_ee.gsc`
+    - Super EE: `super_ee_any_player.gsc`
+  - 3p:-
+    - Die Rise: `die_rise_any_player_ee.gsc`
+    - Buried Richtofen:
+      - `buried_any_player_ee.gsc`
+    - Super EE: `super_ee_any_player.gsc`
+  - 4p:- None
+  - More than 4p:-
+    - Super EE: `super_ee_any_player.gsc`
+
+## - Q: On TranZit, should I worry that Maxis says the Turbine does not have enough power shortly after placing the Turbine under the tower?
+A: Likely a vanilla game issue, especially if the Turbine begins not emitting power. If the Turbine is emitting power, then you probably should not worry.
+
+- Q: On Die Rise, why is the elevator step not completing even though we are standing on enough elevator symbols?
+A: Vanilla game problem. You need to make sure the Nav Table is fully built.
+
+## - Q: On Die Rise, why is the Ballistic Knife step not completing even though Maxis said his quote about reincarnation, and the Ballistic Knife is upgraded and is shot into the Buddha room?
+A: Vanilla game problem. The player shooting the Ballistic Knife must not have a melee weapon (Bowie Knife, Galvaknuckles) nor have bled out (includes, even while having Who's Who, falling off the map and getting crushed). To fix this, either get another player—who does not have a melee weapon nor has bled out—to do the step, or if the player has a melee weapon but has not bled out, make them get rid of the melee weapon by downing while having Who's Who and letting their original self disappear.
+
+# Credits
+- CCDeroga: [TranZit Maxis mod](https://forum.plutonium.pw/topic/15338/zm-release-solo-maxis-tranzit), [Buried Maxis mod](https://forum.plutonium.pw/topic/15604/release-zm-buried-maxis-solo-ee).
+- teh_bandit: Contributions mentioned in the credited people's scripts.
+- DaddyDontStop: [Die Rise Maxis mod](https://forum.plutonium.pw/topic/16736/release-zombies-die-rise-solo-ee-maxis), Buried Maxis mod.
+- shyperson0/znchi: [Die Rise Richtofen mod](https://forum.plutonium.pw/topic/14737/gsc-zm-solo-die-rise-richtofen).
+- Stick Gaming/Nathan3197: [Buried Richtofen mod](https://forum.plutonium.pw/topic/16021/release-zm-buried-easter-egg-quality-of-life-improvement).
+- Raheem1 and the Easter Egg speedrunning community: testing my Die Rise's mod, and giving opinions on my changes made to Die Rise's mod and Buried's mod.

--- a/buried_any_player_ee.gsc
+++ b/buried_any_player_ee.gsc
@@ -51,7 +51,7 @@ _are_all_players_in_time_bomb_volume_qol( e_volume )
 	if ( getPlayers().size <= 3 )
 		n_required_players = a_players.size;
 /#
-	if ( getdvarint( #"5256118F" ) > 0 )
+	if ( getdvarint( #"_id_5256118F" ) > 0 )
 		n_required_players = a_players.size;
 #/
 	n_players_in_position = 0;

--- a/die_rise_any_player_ee.gsc
+++ b/die_rise_any_player_ee.gsc
@@ -171,7 +171,7 @@ custom_get_number_of_players()
 
 // Trample Steam steps
 
-//if the number of players is less than or equal to 2 and a ball is placed for the Maxis Trample Steam step, keeps the trigger to place a new ball for the Trample Steam it was placed on and the one opposite from it
+//if the number of players is less than or equal to 3 and a ball is placed for the Maxis Trample Steam step, keeps the trigger to place a new ball for the Trample Steam it was placed on and the one opposite from it
 //if the number of players is 3, creates trigs for each player already carrying a ball to enable them to place the ball on the lone Trample Steam if the Trample Steam was correctly placed before the 1st ball is launched.
 custom_place_ball_think( t_place_ball, s_lion_spot )
 {
@@ -180,7 +180,7 @@ custom_place_ball_think( t_place_ball, s_lion_spot )
 	t_place_ball waittill( "trigger" );
 
 	a_players = getPlayers();
-	if ( a_players.size > 2 )
+	if ( a_players.size > 3 )
 	{
 		pts_putdown_trigs_remove_for_spot( s_lion_spot );
 		pts_putdown_trigs_remove_for_spot( s_lion_spot.springpad_buddy );
@@ -253,10 +253,10 @@ custom_pts_should_springpad_create_trigs( s_lion_spot )
 	}
 }
 
-//if the number of players is 2 or less, once a ball is picked up, gives the ability to place a 2nd ball on a set of Trample Steams that already has a ball flinging from them for the Maxis Trample Steam step
+//if the number of players is 3 or less, once a ball is picked up, gives the ability to place a 2nd ball on a set of Trample Steams that already has a ball flinging from them for the Maxis Trample Steam step
 custom_pts_putdown_trigs_create_for_spot( s_lion_spot, player )
 {
-	if ( ( isdefined( s_lion_spot.which_ball ) || isdefined( s_lion_spot.springpad_buddy ) && isdefined( s_lion_spot.springpad_buddy.which_ball ) ) && getPlayers().size > 2 )
+	if ( ( isdefined( s_lion_spot.which_ball ) || isdefined( s_lion_spot.springpad_buddy ) && isdefined( s_lion_spot.springpad_buddy.which_ball ) ) && getPlayers().size > 3 )
 		return;
 
 	t_place_ball = sq_pts_create_use_trigger( s_lion_spot.origin, 16, 70, &"ZM_HIGHRISE_SQ_PUTDOWN_BALL" );

--- a/super_ee_any_player.gsc
+++ b/super_ee_any_player.gsc
@@ -70,7 +70,7 @@ custom_sq_metagame()
 	if ( player_count > 4 ) //in case of more than 4 players, only checks the progress of 4 players
 		player_count = 4;
 /#
-	if ( getdvarint( #"FA81816F" ) >= 1 )
+	if ( getdvarint( #"_id_FA81816F" ) >= 1 )
 		player_count = 4;
 #/
 	for ( n_player = 0; n_player < player_count; n_player++ )
@@ -83,10 +83,10 @@ custom_sq_metagame()
 				n_stat_nav_value = players[n_player] maps\mp\zombies\_zm_stats::get_global_stat( a_stat_nav[n_stat] );
 			}
 /#
-			if ( getdvarint( #"FA81816F" ) >= 1 )
+			if ( getdvarint( #"_id_FA81816F" ) >= 1 )
 			{
-				n_stat_value = getdvarint( #"FA81816F" );
-				n_stat_nav_value = getdvarint( #"FA81816F" );
+				n_stat_value = getdvarint( #"_id_FA81816F" );
+				n_stat_nav_value = getdvarint( #"_id_FA81816F" );
 			}
 #/
 			if ( n_stat_value == 1 )


### PR DESCRIPTION
* Update die_rise_any_player_ee.gsc

For 3p, changed to not remove the ability to place the 2nd ball on the same set of Trample Steams as the 1st ball on the Maxis side

* Update README.md

Reformatting to match the post on Plutonium and changing to show the change applied to `die_rise_any_player_ee.gsc`

Fix formatting

* Edited hashed dvar names

Edited to match the Plutonium script dump