### PR TITLE
Version 1.4.3

### DIFF
--- a/crc32_checksums.txt
+++ b/crc32_checksums.txt
@@ -15,7 +15,8 @@ Patches\buried_any_player_ee-body_fix.gsc
 - 0x568DF4F4 (1.1.1)
 
 zm_any_player_ee\scripts\zm\Patches\die_rise_any_player_ee-no_reset.gsc
-- 0x26933213 (1.4.3–current)
+- 0x1EF98907 (1.4.3–current)
+- 0x26933213
 - 0xA093404A
 - 0x52D977F1
 - 0x521D8897
@@ -66,7 +67,8 @@ zm_any_player_ee\scripts\zm\zm_buried\super_ee_any_player.gsc
 - 0x656E442D (1.1.1)
 
 zm_any_player_ee\scripts\zm\zm_highrise\die_rise_any_player_ee.gsc
-- 0x6692024B (1.4.3–current)
+- 0xFB0503AE (1.4.3–current)
+- 0x6692024B
 - 0x9818CD7E
 - 0x068307B0
 - 0x7596755E

--- a/crc32_checksums.txt
+++ b/crc32_checksums.txt
@@ -12,7 +12,8 @@ Patches\buried_any_player_ee-body_fix.gsc
 - 0x568DF4F4 (1.1.1)
 
 zm_any_player_ee\scripts\zm\Patches\die_rise_any_player_ee-no_reset.gsc
-- 0x40D123A2 (1.4.1–current)
+- 0x521D8897 (1.4.3–current)
+- 0x40D123A2 (1.4.1–1.4.2)
 - 0x7F2D43AA
 - 0x4BE7BCE4 (1.4.0)
 - 0x7EBE8CC3 (1.3.1)
@@ -55,7 +56,8 @@ zm_any_player_ee\scripts\zm\zm_buried\super_ee_any_player.gsc
 - 0x656E442D (1.1.1)
 
 zm_any_player_ee\scripts\zm\zm_highrise\die_rise_any_player_ee.gsc
-- 0x0ED18774 (1.4.1–current)
+- 0x7596755E (1.4.3–current)
+- 0x0ED18774 (1.4.1–1.4.2)
 - 0x72BE77BF
 - 0xC7C5B6DA (1.4.0)
 - 0x9430461C (1.3.1)

--- a/crc32_checksums.txt
+++ b/crc32_checksums.txt
@@ -1,5 +1,6 @@
 zm_any_player_ee\scripts\zm\Patches\buried_body_fix.gsc
-- 0x4760097D (1.4.3-current)
+- 0xEB48378D (1.4.3-current)
+- 0x4760097D
 - 0xDDBEDEF9 (1.4.2)
 - 0xFFEFA654 (1.3.1–1.4.1)
 - 0x44907E92 (1.2.1–1.3.0)
@@ -14,7 +15,8 @@ Patches\buried_any_player_ee-body_fix.gsc
 - 0x568DF4F4 (1.1.1)
 
 zm_any_player_ee\scripts\zm\Patches\die_rise_any_player_ee-no_reset.gsc
-- 0xA093404A (1.4.3–current)
+- 0x26933213 (1.4.3–current)
+- 0xA093404A
 - 0x52D977F1
 - 0x521D8897
 - 0x40D123A2 (1.4.1–1.4.2)
@@ -28,7 +30,8 @@ zm_any_player_ee\scripts\zm\Patches\die_rise_any_player_ee-no_reset.gsc
 - 0xA3DABB4E (1.1.1)
 
 zm_any_player_ee\scripts\zm\Patches\nav_autocomplete.gsc
-- 0x7CB74F0C (1.4.1–current)
+- 0x0BB2483E (1.4.3–current)
+- 0x7CB74F0C (1.4.1–1.4.2)
 - 0x86564978 (1.4.0)
 - 0xF7EA9F64 (1.3.1)
 - 0x15822B0C (1.3.0)
@@ -36,7 +39,8 @@ zm_any_player_ee\scripts\zm\Patches\nav_autocomplete.gsc
 - 0xEEFA8398 (after 1.2.1)
 
 zm_any_player_ee\scripts\zm\zm_buried\buried_any_player_ee.gsc
-- 0x4C2200B1 (1.4.2–current)
+- 0xA3A3B3F2 (1.4.3–current)
+- 0x4C2200B1 (1.4.2)
 - 0x009B30BD (1.4.1)
 - 0xAF03CA01 (1.4.0)
 - 0xCB07CF9D (1.3.1)
@@ -49,7 +53,8 @@ zm_any_player_ee\scripts\zm\zm_buried\buried_any_player_ee.gsc
 - 0xE12A442A (1.0–1.1)
 
 zm_any_player_ee\scripts\zm\zm_buried\super_ee_any_player.gsc
-- 0x517EC41C (1.4.0–current)
+- 0x9E9EA583 (1.4.3–current)
+- 0x517EC41C (1.4.0–1.4.2)
 - 0x55CABDD7 (1.3.1)
 - 0x7145975A (1.2.1–1.3.0)
 - 0x8F24E14F (1.2)
@@ -60,7 +65,8 @@ zm_any_player_ee\scripts\zm\zm_buried\super_ee_any_player.gsc
 - 0x656E442D (1.1.1)
 
 zm_any_player_ee\scripts\zm\zm_highrise\die_rise_any_player_ee.gsc
-- 0x9818CD7E (1.4.3–current)
+- 0x6692024B (1.4.3–current)
+- 0x9818CD7E
 - 0x068307B0
 - 0x7596755E
 - 0x0ED18774 (1.4.1–1.4.2)
@@ -76,7 +82,8 @@ zm_any_player_ee\scripts\zm\zm_highrise\die_rise_any_player_ee.gsc
 - 0xEF681238 (1.0)
 
 zm_any_player_ee\scripts\zm\zm_transit\tranzit_maxis_any_player_ee.gsc
-- 0x028E4FEF (1.4.1–current)
+- 0xA54994AF (1.4.3–current)
+- 0x028E4FEF (1.4.1–1.4.2)
 - 0xEE8CDC79
 
 zm_any_player_ee\scripts\zm\zm_transit\tranzit_any_player_ee.gsc

--- a/crc32_checksums.txt
+++ b/crc32_checksums.txt
@@ -7,6 +7,7 @@ Patches\buried_any_player_ee-body_fix.gsc
 - 0x6DC14AE8 (1.2)
 - 0xB0D3D17A
 - 0x066A80D3 (1.1.2)
+- 0xEE2D1900
 - 0xCF8863F7
 - 0xA41CCE54
 - 0x568DF4F4 (1.1.1)

--- a/crc32_checksums.txt
+++ b/crc32_checksums.txt
@@ -14,7 +14,8 @@ Patches\buried_any_player_ee-body_fix.gsc
 - 0x568DF4F4 (1.1.1)
 
 zm_any_player_ee\scripts\zm\Patches\die_rise_any_player_ee-no_reset.gsc
-- 0x52D977F1 (1.4.3–current)
+- 0xA093404A (1.4.3–current)
+- 0x52D977F1
 - 0x521D8897
 - 0x40D123A2 (1.4.1–1.4.2)
 - 0x7F2D43AA
@@ -59,7 +60,8 @@ zm_any_player_ee\scripts\zm\zm_buried\super_ee_any_player.gsc
 - 0x656E442D (1.1.1)
 
 zm_any_player_ee\scripts\zm\zm_highrise\die_rise_any_player_ee.gsc
-- 0x068307B0 (1.4.3–current)
+- 0x9818CD7E (1.4.3–current)
+- 0x068307B0
 - 0x7596755E
 - 0x0ED18774 (1.4.1–1.4.2)
 - 0x72BE77BF

--- a/crc32_checksums.txt
+++ b/crc32_checksums.txt
@@ -1,5 +1,6 @@
 zm_any_player_ee\scripts\zm\Patches\buried_body_fix.gsc
-- 0xDDBEDEF9 (1.4.2-current)
+- 0x4760097D (1.4.3-current)
+- 0xDDBEDEF9 (1.4.2)
 - 0xFFEFA654 (1.3.1–1.4.1)
 - 0x44907E92 (1.2.1–1.3.0)
 

--- a/crc32_checksums.txt
+++ b/crc32_checksums.txt
@@ -13,7 +13,8 @@ Patches\buried_any_player_ee-body_fix.gsc
 - 0x568DF4F4 (1.1.1)
 
 zm_any_player_ee\scripts\zm\Patches\die_rise_any_player_ee-no_reset.gsc
-- 0x521D8897 (1.4.3–current)
+- 0x52D977F1 (1.4.3–current)
+- 0x521D8897
 - 0x40D123A2 (1.4.1–1.4.2)
 - 0x7F2D43AA
 - 0x4BE7BCE4 (1.4.0)
@@ -57,7 +58,8 @@ zm_any_player_ee\scripts\zm\zm_buried\super_ee_any_player.gsc
 - 0x656E442D (1.1.1)
 
 zm_any_player_ee\scripts\zm\zm_highrise\die_rise_any_player_ee.gsc
-- 0x7596755E (1.4.3–current)
+- 0x068307B0 (1.4.3–current)
+- 0x7596755E
 - 0x0ED18774 (1.4.1–1.4.2)
 - 0x72BE77BF
 - 0xC7C5B6DA (1.4.0)

--- a/crc32_checksums.txt
+++ b/crc32_checksums.txt
@@ -30,7 +30,8 @@ zm_any_player_ee\scripts\zm\Patches\die_rise_any_player_ee-no_reset.gsc
 - 0xA3DABB4E (1.1.1)
 
 zm_any_player_ee\scripts\zm\Patches\nav_autocomplete.gsc
-- 0x0BB2483E (1.4.3–current)
+- 0xF1765824 (1.4.3–current)
+- 0x0BB2483E
 - 0x7CB74F0C (1.4.1–1.4.2)
 - 0x86564978 (1.4.0)
 - 0xF7EA9F64 (1.3.1)

--- a/zm_any_player_ee/mod.json
+++ b/zm_any_player_ee/mod.json
@@ -2,5 +2,5 @@
 	"name": "zm_any_player_ee",
 	"author": "Hadi77KSA",
 	"description": "Victis Easter Eggs with any amount of players",
-	"version": "1.4.2"
+	"version": "1.4.3"
 }

--- a/zm_any_player_ee/scripts/zm/Patches/buried_body_fix.gsc
+++ b/zm_any_player_ee/scripts/zm/Patches/buried_body_fix.gsc
@@ -22,6 +22,6 @@ sq_tpo_body_fix()
 			wait 0.05;
 
 		if ( common_scripts\utility::flag( "sq_tpo_special_round_active" ) )
-			level.sq_tpo.times_searched++;
+			level.sq_tpo.times_searched = 3;
 	}
 }

--- a/zm_any_player_ee/scripts/zm/Patches/buried_body_fix.gsc
+++ b/zm_any_player_ee/scripts/zm/Patches/buried_body_fix.gsc
@@ -5,23 +5,33 @@
 //and the need for this fix. Since that turned out to not be the case, this fix is no longer
 //necessary. However, I will keep it as there are approved runs on ZWR which have used it.
 
+#include common_scripts\utility;
+
 init()
 {
-	thread sq_tpo_body_fix();
+	if ( getdvar( "mapname" ) == "zm_buried" && maps\mp\zombies\_zm_sidequests::is_sidequest_allowed( "zclassic" ) )
+		thread sq_tpo_body_fix();
 }
 
 sq_tpo_body_fix()
 {
+	flag_wait( "start_zombie_round_logic" );
+	waittillframeend;
+
+	if ( level.richcompleted )
+		return;
+
+	level endon( "sq_is_max_tower_built" );
 	level endon( "sq_tpo_generator_powered" );
 
 	for (;;)
 	{
 		level waittill( "sq_tpo_special_round_started" );
 
-		while ( common_scripts\utility::flag( "sq_tpo_special_round_active" ) && level.sq_tpo.times_searched < 2 )
+		while ( flag( "sq_tpo_special_round_active" ) && level.sq_tpo.times_searched < 2 )
 			wait 0.05;
 
-		if ( common_scripts\utility::flag( "sq_tpo_special_round_active" ) )
+		if ( flag( "sq_tpo_special_round_active" ) )
 			level.sq_tpo.times_searched = 3;
 	}
 }

--- a/zm_any_player_ee/scripts/zm/Patches/die_rise_any_player_ee-no_reset.gsc
+++ b/zm_any_player_ee/scripts/zm/Patches/die_rise_any_player_ee-no_reset.gsc
@@ -23,13 +23,7 @@ init()
 	if ( set_dvar_int_if_unset( "any_player_ee_highrise_nav", "1" ) )
 		thread buildNavTable();
 
-	level waittill( "sq_slb_over" );
-
-	if ( !level.richcompleted )
-		thread sq_1();
-
-	if ( !level.maxcompleted )
-		thread sq_2();
+	thread set_n_players_at_pts_start();
 }
 
 onPlayerConnect()
@@ -58,6 +52,17 @@ buildNavTable()
 		if ( !player maps\mp\zombies\_zm_stats::get_global_stat( "sq_highrise_started" ) )
 			maps\mp\zm_highrise_sq::update_sidequest_stats( "sq_highrise_started" );
 	}
+}
+
+set_n_players_at_pts_start()
+{
+	level waittill( "sq_slb_over" );
+
+	if ( !level.richcompleted )
+		thread sq_1();
+
+	if ( !level.maxcompleted )
+		thread sq_2();
 }
 
 //Elevator Stand step

--- a/zm_any_player_ee/scripts/zm/Patches/die_rise_any_player_ee-no_reset.gsc
+++ b/zm_any_player_ee/scripts/zm/Patches/die_rise_any_player_ee-no_reset.gsc
@@ -23,7 +23,7 @@ init()
 	if ( set_dvar_int_if_unset( "any_player_ee_highrise_nav", "1" ) )
 		thread buildNavTable();
 
-	thread set_n_players_at_pts_start();
+	thread handle_n_players_since_pts_start();
 }
 
 onPlayerConnect()
@@ -54,7 +54,7 @@ buildNavTable()
 	}
 }
 
-set_n_players_at_pts_start()
+handle_n_players_since_pts_start()
 {
 	level waittill( "sq_slb_over" );
 
@@ -215,11 +215,15 @@ custom_get_number_of_players( is_generator )
 
 sq_1()
 {
+	level endon( "sq_ball_picked_up" );
 	level waittill( "sq_1_pts_1_started" );
 	level.n_players_since_rich_pts_start = get_players().size;
 
 	foreach ( player in get_players() )
 		player thread onPlayerDisconnect( 0 );
+
+	level waittill( "pts_1_springpads_placed" );
+	level.n_players_since_rich_pts_start = undefined;
 }
 
 sq_2()
@@ -390,6 +394,9 @@ custom_pts_putdown_trigs_create_for_spot( s_lion_spot, player )
 
 onPlayerDisconnect( is_generator )
 {
+	if ( !is_generator )
+		level endon( "pts_1_springpads_placed" );
+
 	self waittill( "disconnect" );
 
 	if ( is_generator )

--- a/zm_any_player_ee/scripts/zm/Patches/die_rise_any_player_ee-no_reset.gsc
+++ b/zm_any_player_ee/scripts/zm/Patches/die_rise_any_player_ee-no_reset.gsc
@@ -5,15 +5,14 @@
 
 main()
 {
-	replaceFunc( ::sq_atd_elevators, ::custom_sq_atd_elevators );
-	replaceFunc( ::sq_atd_drg_puzzle, ::custom_sq_atd_drg_puzzle );
-	replaceFunc( ::drg_puzzle_trig_think, ::custom_drg_puzzle_trig_think );
-	replaceFunc( ::wait_for_all_springpads_placed, ::custom_wait_for_all_springpads_placed );
-	replaceFunc( ::springpad_count_watcher, ::custom_springpad_count_watcher );
-	replaceFunc( ::pts_should_player_create_trigs, ::custom_pts_should_player_create_trigs );
-	replaceFunc( ::pts_should_springpad_create_trigs, ::custom_pts_should_springpad_create_trigs );
-	replaceFunc( ::pts_putdown_trigs_create_for_spot, ::custom_pts_putdown_trigs_create_for_spot );
-	replaceFunc( ::place_ball_think, ::custom_place_ball_think );
+	replaceFunc( maps\mp\zm_highrise_sq_atd::sq_atd_elevators, ::sq_atd_elevators );
+	replaceFunc( maps\mp\zm_highrise_sq_atd::sq_atd_drg_puzzle, ::sq_atd_drg_puzzle );
+	replaceFunc( maps\mp\zm_highrise_sq_atd::drg_puzzle_trig_think, ::drg_puzzle_trig_think );
+	replaceFunc( maps\mp\zm_highrise_sq_pts::wait_for_all_springpads_placed, ::wait_for_all_springpads_placed );
+	replaceFunc( maps\mp\zm_highrise_sq_pts::pts_should_player_create_trigs, ::pts_should_player_create_trigs );
+	replaceFunc( maps\mp\zm_highrise_sq_pts::pts_should_springpad_create_trigs, ::pts_should_springpad_create_trigs );
+	replaceFunc( maps\mp\zm_highrise_sq_pts::pts_putdown_trigs_create_for_spot, ::pts_putdown_trigs_create_for_spot );
+	replaceFunc( maps\mp\zm_highrise_sq_pts::place_ball_think, ::place_ball_think );
 }
 
 init()
@@ -74,10 +73,24 @@ handle_n_players_since_pts_start()
 		thread sq_2();
 }
 
+//returns the number of players, and if the number is greater than 4, returns 4. Used for specific steps
+custom_get_number_of_players( is_generator )
+{
+	n_players = getPlayers().size;
+
+	if ( isdefined( is_generator ) && !is_generator && isdefined( level.n_players_since_rich_pts_start ) )
+		n_players = level.n_players_since_rich_pts_start;
+
+	if ( n_players > 4 )
+		n_players = 4;
+
+	return n_players;
+}
+
 //Elevator Stand step
 
 //makes elevator symbols require as many symbols as players
-custom_sq_atd_elevators()
+sq_atd_elevators()
 {
 	a_elevators = array( "elevator_bldg1b_trigger", "elevator_bldg1d_trigger", "elevator_bldg3b_trigger", "elevator_bldg3c_trigger" );
 	a_elevator_flags = array( "sq_atd_elevator0", "sq_atd_elevator1", "sq_atd_elevator2", "sq_atd_elevator3" );
@@ -133,7 +146,7 @@ standing_on_enough_elevators_check( a_elevator_flags )
 //Dragon Puzzle step
 
 //initialises the floor symbols to require as many symbols as players
-custom_sq_atd_drg_puzzle()
+sq_atd_drg_puzzle()
 {
 	level.sq_atd_cur_drg = 4 - custom_get_number_of_players();
 	a_puzzle_trigs = getentarray( "trig_atd_drg_puzzle", "targetname" );
@@ -153,7 +166,7 @@ custom_sq_atd_drg_puzzle()
 }
 
 //when floor symbols reset, they reset back to require as many symbols as players
-custom_drg_puzzle_trig_think( n_order_id )
+drg_puzzle_trig_think( n_order_id )
 {
 	self.drg_active = 0;
 	m_unlit = getent( self.target, "targetname" );
@@ -206,20 +219,6 @@ custom_drg_puzzle_trig_think( n_order_id )
 	}
 }
 
-//returns the number of players, and if the number is greater than 4, returns 4. Used for specific steps
-custom_get_number_of_players( is_generator )
-{
-	n_players = getPlayers().size;
-
-	if ( isdefined( is_generator ) && !is_generator && isdefined( level.n_players_since_rich_pts_start ) )
-		n_players = level.n_players_since_rich_pts_start;
-
-	if ( n_players > 4 )
-		n_players = 4;
-
-	return n_players;
-}
-
 // Trample Steam steps
 
 sq_1()
@@ -244,9 +243,28 @@ sq_2()
 		player thread onPlayerDisconnect( 1 );
 }
 
+onPlayerDisconnect( is_generator )
+{
+	if ( !is_generator )
+		level endon( "pts_1_springpads_placed" );
+
+	self waittill( "disconnect" );
+
+	if ( is_generator )
+	{
+		if ( isdefined( level.n_players_since_maxis_pts_start ) )
+			level.n_players_since_maxis_pts_start--;
+	}
+	else
+	{
+		if ( isdefined( level.n_players_since_rich_pts_start ) )
+			level.n_players_since_rich_pts_start--;
+	}
+}
+
 //if the number of players is less than or equal to 3 and a ball is placed for the Maxis Trample Steam step, keeps the trigger to place a new ball for the Trample Steam it was placed on and the one opposite from it
 //if the number of players is 3, creates trigs for each player already carrying a ball to enable them to place the ball on the lone Trample Steam if the Trample Steam was correctly placed before the 1st ball is launched.
-custom_place_ball_think( t_place_ball, s_lion_spot )
+place_ball_think( t_place_ball, s_lion_spot )
 {
 	t_place_ball endon( "delete" );
 	t_place_ball waittill( "trigger" );
@@ -268,6 +286,9 @@ custom_place_ball_think( t_place_ball, s_lion_spot )
 /#
 	iprintlnbold( "Ball Animating" );
 #/
+	if ( !isdefined( s_lion_spot.springpad_buddy.springpad ) )
+		s_lion_spot.springpad_buddy.springpad = s_lion_spot.springpad;
+
 	s_lion_spot.springpad thread pts_springpad_fling( s_lion_spot.script_noteworthy, s_lion_spot.springpad_buddy.springpad );
 	self.t_putdown_ball delete();
 
@@ -293,44 +314,8 @@ pts_should_placing_ball_create_trigs( s_lion_spot_used, player )
 	}
 }
 
-//quotes skip for Richtofen Trample Steams
-custom_springpad_count_watcher( is_generator )
-{
-	level endon( "sq_pts_springad_count4" );
-	str_which_spots = "pts_ghoul";
-
-	if ( is_generator )
-		str_which_spots = "pts_lion";
-
-	a_spots = getstructarray( str_which_spots, "targetname" );
-
-	while ( true )
-	{
-		level waittill( "sq_pts_springpad_in_place" );
-		n_count = 0;
-
-		foreach ( s_spot in a_spots )
-		{
-			if ( isdefined( s_spot.springpad ) )
-				n_count++;
-		}
-
-		level notify( "sq_pts_springad_count" + n_count );
-
-		if ( !is_generator && n_count >= custom_get_number_of_players( 0 ) )
-		{
-			while ( n_count < 4 )
-			{
-				wait 10;
-				n_count++;
-				level notify( "sq_pts_springad_count" + n_count );
-			}
-		}
-	}
-}
-
 //makes Richtofen Trample Steam step require as many as players
-custom_wait_for_all_springpads_placed( str_type, str_flag )
+wait_for_all_springpads_placed( str_type, str_flag )
 {
 	a_spots = getstructarray( str_type, "targetname" );
 
@@ -352,7 +337,7 @@ custom_wait_for_all_springpads_placed( str_type, str_flag )
 }
 
 //on the Maxis side if the player is playing solo or 3p, once the player picks up a ball, gives the player the ability to place the ball on an already correctly placed Trample Steam without needing a Trample Steam on the opposite end. On 3p, this is executed if the ball is picked up while there's already a ball flinging.
-custom_pts_should_player_create_trigs( player )
+pts_should_player_create_trigs( player )
 {
 	a_lion_spots = getstructarray( "pts_lion", "targetname" );
 
@@ -364,7 +349,7 @@ custom_pts_should_player_create_trigs( player )
 }
 
 //on the Maxis side if the player is playing solo or 3p, once a player places a Trample Steam correctly, gives each player already carrying a ball the ability to place it without needing a Trample Steam on the opposite end. On 3p, this is executed if the Trample Steam is placed while there's already a ball flinging.
-custom_pts_should_springpad_create_trigs( s_lion_spot )
+pts_should_springpad_create_trigs( s_lion_spot )
 {
 	if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || ( isdefined( level.n_players_since_maxis_pts_start ) && ( level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) ) ) )
 	{
@@ -384,7 +369,7 @@ custom_pts_should_springpad_create_trigs( s_lion_spot )
 }
 
 //if the number of players is 3 or less, once a ball is picked up, gives the ability to place a 2nd ball on a set of Trample Steams that already has a ball flinging from them for the Maxis Trample Steam step
-custom_pts_putdown_trigs_create_for_spot( s_lion_spot, player )
+pts_putdown_trigs_create_for_spot( s_lion_spot, player )
 {
 	if ( ( !isdefined( level.n_players_since_maxis_pts_start ) || level.n_players_since_maxis_pts_start >= 4 ) && ( isdefined( s_lion_spot.which_ball ) || isdefined( s_lion_spot.springpad_buddy ) && isdefined( s_lion_spot.springpad_buddy.which_ball ) ) )
 		return;
@@ -399,23 +384,4 @@ custom_pts_putdown_trigs_create_for_spot( s_lion_spot, player )
 
 	s_lion_spot.pts_putdown_trigs[player.characterindex] = t_place_ball;
 	level thread pts_putdown_trigs_springpad_delete_watcher( player, s_lion_spot );
-}
-
-onPlayerDisconnect( is_generator )
-{
-	if ( !is_generator )
-		level endon( "pts_1_springpads_placed" );
-
-	self waittill( "disconnect" );
-
-	if ( is_generator )
-	{
-		if ( isdefined( level.n_players_since_maxis_pts_start ) )
-			level.n_players_since_maxis_pts_start--;
-	}
-	else
-	{
-		if ( isdefined( level.n_players_since_rich_pts_start ) )
-			level.n_players_since_rich_pts_start--;
-	}
 }

--- a/zm_any_player_ee/scripts/zm/Patches/die_rise_any_player_ee-no_reset.gsc
+++ b/zm_any_player_ee/scripts/zm/Patches/die_rise_any_player_ee-no_reset.gsc
@@ -22,6 +22,14 @@ init()
 
 	if ( set_dvar_int_if_unset( "any_player_ee_highrise_nav", "1" ) )
 		thread buildNavTable();
+
+	level waittill( "sq_slb_over" );
+
+	if ( !level.richcompleted )
+		thread sq_1();
+
+	if ( !level.maxcompleted )
+		thread sq_2();
 }
 
 onPlayerConnect()
@@ -45,7 +53,7 @@ buildNavTable()
 {
 	flag_wait( "initial_players_connected" );
 
-	foreach ( player in getPlayers() )
+	foreach ( player in get_players() )
 	{
 		if ( !player maps\mp\zombies\_zm_stats::get_global_stat( "sq_highrise_started" ) )
 			maps\mp\zm_highrise_sq::update_sidequest_stats( "sq_highrise_started" );
@@ -185,9 +193,12 @@ custom_drg_puzzle_trig_think( n_order_id )
 }
 
 //returns the number of players, and if the number is greater than 4, returns 4. Used for specific steps
-custom_get_number_of_players()
+custom_get_number_of_players( is_generator )
 {
 	n_players = getPlayers().size;
+
+	if ( isdefined( is_generator ) && !is_generator )
+		n_players = level.n_players_since_rich_pts_start;
 
 	if ( n_players > 4 )
 		n_players = 4;
@@ -197,15 +208,32 @@ custom_get_number_of_players()
 
 // Trample Steam steps
 
+sq_1()
+{
+	level waittill( "sq_1_pts_1_started" );
+	level.n_players_since_rich_pts_start = get_players().size;
+
+	foreach ( player in get_players() )
+		player thread onPlayerDisconnect( 0 );
+}
+
+sq_2()
+{
+	level waittill( "sq_2_pts_2_started" );
+	level.n_players_since_maxis_pts_start = get_players().size;
+
+	foreach ( player in get_players() )
+		player thread onPlayerDisconnect( 1 );
+}
+
 //if the number of players is less than or equal to 3 and a ball is placed for the Maxis Trample Steam step, keeps the trigger to place a new ball for the Trample Steam it was placed on and the one opposite from it
 //if the number of players is 3, creates trigs for each player already carrying a ball to enable them to place the ball on the lone Trample Steam if the Trample Steam was correctly placed before the 1st ball is launched.
 custom_place_ball_think( t_place_ball, s_lion_spot )
 {
 	t_place_ball endon( "delete" );
 	t_place_ball waittill( "trigger" );
-	n_players = getPlayers().size;
 
-	if ( n_players > 3 )
+	if ( level.n_players_since_maxis_pts_start > 3 )
 	{
 		pts_putdown_trigs_remove_for_spot( s_lion_spot );
 		pts_putdown_trigs_remove_for_spot( s_lion_spot.springpad_buddy );
@@ -225,7 +253,7 @@ custom_place_ball_think( t_place_ball, s_lion_spot )
 	s_lion_spot.springpad thread pts_springpad_fling( s_lion_spot.script_noteworthy, s_lion_spot.springpad_buddy.springpad );
 	self.t_putdown_ball delete();
 
-	if ( n_players == 3 )
+	if ( level.n_players_since_maxis_pts_start == 3 )
 	{
 		foreach ( player in getPlayers() )
 		{
@@ -271,7 +299,7 @@ custom_springpad_count_watcher( is_generator )
 
 		level notify( "sq_pts_springad_count" + n_count );
 
-		if ( !is_generator && n_count >= custom_get_number_of_players() )
+		if ( !is_generator && n_count >= custom_get_number_of_players( 0 ) )
 		{
 			while ( n_count < 4 )
 			{
@@ -298,7 +326,7 @@ custom_wait_for_all_springpads_placed( str_type, str_flag )
 				is_clear++;
 		}
 
-		if ( !( is_clear > ( 4 - custom_get_number_of_players() ) ) )
+		if ( is_clear <= 4 - custom_get_number_of_players( 0 ) )
 			flag_set( str_flag );
 
 		wait 1;
@@ -309,11 +337,10 @@ custom_wait_for_all_springpads_placed( str_type, str_flag )
 custom_pts_should_player_create_trigs( player )
 {
 	a_lion_spots = getstructarray( "pts_lion", "targetname" );
-	n_players = getPlayers().size;
 
 	foreach ( s_lion_spot in a_lion_spots )
 	{
-		if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || n_players == 1 || ( n_players == 3 && flag( "pts_2_generator_1_started" ) ) ) )
+		if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) )
 			pts_putdown_trigs_create_for_spot( s_lion_spot, player );
 	}
 }
@@ -321,9 +348,7 @@ custom_pts_should_player_create_trigs( player )
 //on the Maxis side if the player is playing solo or 3p, once a player places a Trample Steam correctly, gives each player already carrying a ball the ability to place it without needing a Trample Steam on the opposite end. On 3p, this is executed if the Trample Steam is placed while there's already a ball flinging.
 custom_pts_should_springpad_create_trigs( s_lion_spot )
 {
-	n_players = getPlayers().size;
-
-	if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || n_players == 1 || ( n_players == 3 && flag( "pts_2_generator_1_started" ) ) ) )
+	if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) )
 	{
 		a_players = getplayers();
 
@@ -343,7 +368,7 @@ custom_pts_should_springpad_create_trigs( s_lion_spot )
 //if the number of players is 3 or less, once a ball is picked up, gives the ability to place a 2nd ball on a set of Trample Steams that already has a ball flinging from them for the Maxis Trample Steam step
 custom_pts_putdown_trigs_create_for_spot( s_lion_spot, player )
 {
-	if ( ( isdefined( s_lion_spot.which_ball ) || isdefined( s_lion_spot.springpad_buddy ) && isdefined( s_lion_spot.springpad_buddy.which_ball ) ) && getPlayers().size > 3 )
+	if ( level.n_players_since_maxis_pts_start >= 4 && ( isdefined( s_lion_spot.which_ball ) || isdefined( s_lion_spot.springpad_buddy ) && isdefined( s_lion_spot.springpad_buddy.which_ball ) ) )
 		return;
 
 	t_place_ball = sq_pts_create_use_trigger( s_lion_spot.origin, 16, 70, &"ZM_HIGHRISE_SQ_PUTDOWN_BALL" );
@@ -356,4 +381,14 @@ custom_pts_putdown_trigs_create_for_spot( s_lion_spot, player )
 
 	s_lion_spot.pts_putdown_trigs[player.characterindex] = t_place_ball;
 	level thread pts_putdown_trigs_springpad_delete_watcher( player, s_lion_spot );
+}
+
+onPlayerDisconnect( is_generator )
+{
+	self waittill( "disconnect" );
+
+	if ( is_generator )
+		level.n_players_since_maxis_pts_start--;
+	else
+		level.n_players_since_rich_pts_start--;
 }

--- a/zm_any_player_ee/scripts/zm/Patches/nav_autocomplete.gsc
+++ b/zm_any_player_ee/scripts/zm/Patches/nav_autocomplete.gsc
@@ -21,7 +21,10 @@ setNavStatsForAllMaps()
 		foreach ( n_stat in a_stat )
 		{
 			if ( !player maps\mp\zombies\_zm_stats::get_global_stat( n_stat ) )
+			{
+				player maps\mp\gametypes_zm\_globallogic_score::initPersStat( n_stat, 0 );
 				player maps\mp\zombies\_zm_stats::increment_client_stat( n_stat, 0 );
+			}
 		}
 	}
 }

--- a/zm_any_player_ee/scripts/zm/Patches/nav_autocomplete.gsc
+++ b/zm_any_player_ee/scripts/zm/Patches/nav_autocomplete.gsc
@@ -1,20 +1,27 @@
 init()
 {
-	mapName = getdvar( "mapname" );
-
-	if ( mapName == "zm_transit" || mapName == "zm_highrise" || mapName == "zm_buried" )
+	switch ( getdvar( "mapname" ) )
 	{
-		a_stat = array( "sq_transit_started", "sq_highrise_started", "sq_buried_started", "navcard_applied_zm_transit", "navcard_applied_zm_highrise", "navcard_applied_zm_buried" );
-		common_scripts\utility::flag_wait( "initial_players_connected" );
+		case "zm_transit":
+		case "zm_highrise":
+		case "zm_buried":
+			thread setNavStatsForAllMaps();
+			break;
+	}
+}
 
-		foreach ( player in getPlayers() )
+setNavStatsForAllMaps()
+{
+	common_scripts\utility::flag_wait( "initial_players_connected" );
+	a_stat = array( "sq_transit_started", "sq_highrise_started", "sq_buried_started", "navcard_applied_zm_transit", "navcard_applied_zm_highrise", "navcard_applied_zm_buried" );
+
+	foreach ( player in getPlayers() )
+	{
+		// Handles building the NAV Tables and applying the Navcards
+		foreach ( n_stat in a_stat )
 		{
-			// Handles building the NAV Tables and applying the Navcards
-			foreach ( n_stat in a_stat )
-			{
-				if ( !player maps\mp\zombies\_zm_stats::get_global_stat( n_stat ) )
-					player maps\mp\zombies\_zm_stats::increment_client_stat( n_stat, 0 );
-			}
+			if ( !player maps\mp\zombies\_zm_stats::get_global_stat( n_stat ) )
+				player maps\mp\zombies\_zm_stats::increment_client_stat( n_stat, 0 );
 		}
 	}
 }

--- a/zm_any_player_ee/scripts/zm/zm_buried/buried_any_player_ee.gsc
+++ b/zm_any_player_ee/scripts/zm/zm_buried/buried_any_player_ee.gsc
@@ -16,7 +16,8 @@ main()
 
 init()
 {
-	thread onPlayerConnect();
+	if ( maps\mp\zombies\_zm_sidequests::is_sidequest_allowed( "zclassic" ) )
+		thread onPlayerConnect();
 }
 
 onPlayerConnect()

--- a/zm_any_player_ee/scripts/zm/zm_buried/super_ee_any_player.gsc
+++ b/zm_any_player_ee/scripts/zm/zm_buried/super_ee_any_player.gsc
@@ -9,7 +9,8 @@ main()
 
 init()
 {
-	thread onPlayerConnect();
+	if ( maps\mp\zombies\_zm_sidequests::is_sidequest_allowed( "zclassic" ) )
+		thread onPlayerConnect();
 }
 
 onPlayerConnect()

--- a/zm_any_player_ee/scripts/zm/zm_highrise/die_rise_any_player_ee.gsc
+++ b/zm_any_player_ee/scripts/zm/zm_highrise/die_rise_any_player_ee.gsc
@@ -23,13 +23,7 @@ init()
 	if ( set_dvar_int_if_unset( "any_player_ee_highrise_nav", "1" ) )
 		thread buildNavTable();
 
-	level waittill( "sq_slb_over" );
-
-	if ( !level.richcompleted )
-		thread sq_1();
-
-	if ( !level.maxcompleted )
-		thread sq_2();
+	thread set_n_players_at_pts_start();
 }
 
 onPlayerConnect()
@@ -58,6 +52,17 @@ buildNavTable()
 		if ( !player maps\mp\zombies\_zm_stats::get_global_stat( "sq_highrise_started" ) )
 			maps\mp\zm_highrise_sq::update_sidequest_stats( "sq_highrise_started" );
 	}
+}
+
+set_n_players_at_pts_start()
+{
+	level waittill( "sq_slb_over" );
+
+	if ( !level.richcompleted )
+		thread sq_1();
+
+	if ( !level.maxcompleted )
+		thread sq_2();
 }
 
 //Elevator Stand step

--- a/zm_any_player_ee/scripts/zm/zm_highrise/die_rise_any_player_ee.gsc
+++ b/zm_any_player_ee/scripts/zm/zm_highrise/die_rise_any_player_ee.gsc
@@ -23,7 +23,7 @@ init()
 	if ( set_dvar_int_if_unset( "any_player_ee_highrise_nav", "1" ) )
 		thread buildNavTable();
 
-	thread set_n_players_at_pts_start();
+	thread handle_n_players_since_pts_start();
 }
 
 onPlayerConnect()
@@ -54,7 +54,7 @@ buildNavTable()
 	}
 }
 
-set_n_players_at_pts_start()
+handle_n_players_since_pts_start()
 {
 	level waittill( "sq_slb_over" );
 
@@ -213,11 +213,15 @@ custom_get_number_of_players( is_generator )
 
 sq_1()
 {
+	level endon( "sq_ball_picked_up" );
 	level waittill( "sq_1_pts_1_started" );
 	level.n_players_since_rich_pts_start = get_players().size;
 
 	foreach ( player in get_players() )
 		player thread onPlayerDisconnect( 0 );
+
+	level waittill( "pts_1_springpads_placed" );
+	level.n_players_since_rich_pts_start = undefined;
 }
 
 sq_2()
@@ -388,6 +392,9 @@ custom_pts_putdown_trigs_create_for_spot( s_lion_spot, player )
 
 onPlayerDisconnect( is_generator )
 {
+	if ( !is_generator )
+		level endon( "pts_1_springpads_placed" );
+
 	self waittill( "disconnect" );
 
 	if ( is_generator )

--- a/zm_any_player_ee/scripts/zm/zm_highrise/die_rise_any_player_ee.gsc
+++ b/zm_any_player_ee/scripts/zm/zm_highrise/die_rise_any_player_ee.gsc
@@ -5,15 +5,14 @@
 
 main()
 {
-	replaceFunc( ::sq_atd_elevators, ::custom_sq_atd_elevators );
-	replaceFunc( ::sq_atd_drg_puzzle, ::custom_sq_atd_drg_puzzle );
-	replaceFunc( ::drg_puzzle_trig_think, ::custom_drg_puzzle_trig_think );
-	replaceFunc( ::wait_for_all_springpads_placed, ::custom_wait_for_all_springpads_placed );
-	replaceFunc( ::springpad_count_watcher, ::custom_springpad_count_watcher );
-	replaceFunc( ::pts_should_player_create_trigs, ::custom_pts_should_player_create_trigs );
-	replaceFunc( ::pts_should_springpad_create_trigs, ::custom_pts_should_springpad_create_trigs );
-	replaceFunc( ::pts_putdown_trigs_create_for_spot, ::custom_pts_putdown_trigs_create_for_spot );
-	replaceFunc( ::place_ball_think, ::custom_place_ball_think );
+	replaceFunc( maps\mp\zm_highrise_sq_atd::sq_atd_elevators, ::sq_atd_elevators );
+	replaceFunc( maps\mp\zm_highrise_sq_atd::sq_atd_drg_puzzle, ::sq_atd_drg_puzzle );
+	replaceFunc( maps\mp\zm_highrise_sq_atd::drg_puzzle_trig_think, ::drg_puzzle_trig_think );
+	replaceFunc( maps\mp\zm_highrise_sq_pts::wait_for_all_springpads_placed, ::wait_for_all_springpads_placed );
+	replaceFunc( maps\mp\zm_highrise_sq_pts::pts_should_player_create_trigs, ::pts_should_player_create_trigs );
+	replaceFunc( maps\mp\zm_highrise_sq_pts::pts_should_springpad_create_trigs, ::pts_should_springpad_create_trigs );
+	replaceFunc( maps\mp\zm_highrise_sq_pts::pts_putdown_trigs_create_for_spot, ::pts_putdown_trigs_create_for_spot );
+	replaceFunc( maps\mp\zm_highrise_sq_pts::place_ball_think, ::place_ball_think );
 }
 
 init()
@@ -74,10 +73,24 @@ handle_n_players_since_pts_start()
 		thread sq_2();
 }
 
+//returns the number of players, and if the number is greater than 4, returns 4. Used for specific steps
+custom_get_number_of_players( is_generator )
+{
+	n_players = getPlayers().size;
+
+	if ( isdefined( is_generator ) && !is_generator && isdefined( level.n_players_since_rich_pts_start ) )
+		n_players = level.n_players_since_rich_pts_start;
+
+	if ( n_players > 4 )
+		n_players = 4;
+
+	return n_players;
+}
+
 //Elevator Stand step
 
 //makes elevator symbols require as many symbols as players
-custom_sq_atd_elevators()
+sq_atd_elevators()
 {
 	a_elevators = array( "elevator_bldg1b_trigger", "elevator_bldg1d_trigger", "elevator_bldg3b_trigger", "elevator_bldg3c_trigger" );
 	a_elevator_flags = array( "sq_atd_elevator0", "sq_atd_elevator1", "sq_atd_elevator2", "sq_atd_elevator3" );
@@ -133,7 +146,7 @@ standing_on_enough_elevators_check( a_elevator_flags )
 //Dragon Puzzle step
 
 //initialises the floor symbols to require as many symbols as players
-custom_sq_atd_drg_puzzle()
+sq_atd_drg_puzzle()
 {
 	level.sq_atd_cur_drg = 4 - custom_get_number_of_players();
 	a_puzzle_trigs = getentarray( "trig_atd_drg_puzzle", "targetname" );
@@ -153,7 +166,7 @@ custom_sq_atd_drg_puzzle()
 }
 
 //when floor symbols reset, they reset back to require as many symbols as players
-custom_drg_puzzle_trig_think( n_order_id )
+drg_puzzle_trig_think( n_order_id )
 {
 	self.drg_active = 0;
 	m_unlit = getent( self.target, "targetname" );
@@ -204,20 +217,6 @@ custom_drg_puzzle_trig_think( n_order_id )
 	}
 }
 
-//returns the number of players, and if the number is greater than 4, returns 4. Used for specific steps
-custom_get_number_of_players( is_generator )
-{
-	n_players = getPlayers().size;
-
-	if ( isdefined( is_generator ) && !is_generator && isdefined( level.n_players_since_rich_pts_start ) )
-		n_players = level.n_players_since_rich_pts_start;
-
-	if ( n_players > 4 )
-		n_players = 4;
-
-	return n_players;
-}
-
 // Trample Steam steps
 
 sq_1()
@@ -242,9 +241,28 @@ sq_2()
 		player thread onPlayerDisconnect( 1 );
 }
 
+onPlayerDisconnect( is_generator )
+{
+	if ( !is_generator )
+		level endon( "pts_1_springpads_placed" );
+
+	self waittill( "disconnect" );
+
+	if ( is_generator )
+	{
+		if ( isdefined( level.n_players_since_maxis_pts_start ) )
+			level.n_players_since_maxis_pts_start--;
+	}
+	else
+	{
+		if ( isdefined( level.n_players_since_rich_pts_start ) )
+			level.n_players_since_rich_pts_start--;
+	}
+}
+
 //if the number of players is less than or equal to 3 and a ball is placed for the Maxis Trample Steam step, keeps the trigger to place a new ball for the Trample Steam it was placed on and the one opposite from it
 //if the number of players is 3, creates trigs for each player already carrying a ball to enable them to place the ball on the lone Trample Steam if the Trample Steam was correctly placed before the 1st ball is launched.
-custom_place_ball_think( t_place_ball, s_lion_spot )
+place_ball_think( t_place_ball, s_lion_spot )
 {
 	t_place_ball endon( "delete" );
 	t_place_ball waittill( "trigger" );
@@ -266,6 +284,9 @@ custom_place_ball_think( t_place_ball, s_lion_spot )
 /#
 	iprintlnbold( "Ball Animating" );
 #/
+	if ( !isdefined( s_lion_spot.springpad_buddy.springpad ) )
+		s_lion_spot.springpad_buddy.springpad = s_lion_spot.springpad;
+
 	s_lion_spot.springpad thread pts_springpad_fling( s_lion_spot.script_noteworthy, s_lion_spot.springpad_buddy.springpad );
 	self.t_putdown_ball delete();
 
@@ -291,44 +312,8 @@ pts_should_placing_ball_create_trigs( s_lion_spot_used, player )
 	}
 }
 
-//quotes skip for Richtofen Trample Steams
-custom_springpad_count_watcher( is_generator )
-{
-	level endon( "sq_pts_springad_count4" );
-	str_which_spots = "pts_ghoul";
-
-	if ( is_generator )
-		str_which_spots = "pts_lion";
-
-	a_spots = getstructarray( str_which_spots, "targetname" );
-
-	while ( true )
-	{
-		level waittill( "sq_pts_springpad_in_place" );
-		n_count = 0;
-
-		foreach ( s_spot in a_spots )
-		{
-			if ( isdefined( s_spot.springpad ) )
-				n_count++;
-		}
-
-		level notify( "sq_pts_springad_count" + n_count );
-
-		if ( !is_generator && n_count >= custom_get_number_of_players( 0 ) )
-		{
-			while ( n_count < 4 )
-			{
-				wait 10;
-				n_count++;
-				level notify( "sq_pts_springad_count" + n_count );
-			}
-		}
-	}
-}
-
 //makes Richtofen Trample Steam step require as many as players
-custom_wait_for_all_springpads_placed( str_type, str_flag )
+wait_for_all_springpads_placed( str_type, str_flag )
 {
 	a_spots = getstructarray( str_type, "targetname" );
 
@@ -350,7 +335,7 @@ custom_wait_for_all_springpads_placed( str_type, str_flag )
 }
 
 //on the Maxis side if the player is playing solo or 3p, once the player picks up a ball, gives the player the ability to place the ball on an already correctly placed Trample Steam without needing a Trample Steam on the opposite end. On 3p, this is executed if the ball is picked up while there's already a ball flinging.
-custom_pts_should_player_create_trigs( player )
+pts_should_player_create_trigs( player )
 {
 	a_lion_spots = getstructarray( "pts_lion", "targetname" );
 
@@ -362,7 +347,7 @@ custom_pts_should_player_create_trigs( player )
 }
 
 //on the Maxis side if the player is playing solo or 3p, once a player places a Trample Steam correctly, gives each player already carrying a ball the ability to place it without needing a Trample Steam on the opposite end. On 3p, this is executed if the Trample Steam is placed while there's already a ball flinging.
-custom_pts_should_springpad_create_trigs( s_lion_spot )
+pts_should_springpad_create_trigs( s_lion_spot )
 {
 	if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || ( isdefined( level.n_players_since_maxis_pts_start ) && ( level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) ) ) )
 	{
@@ -382,7 +367,7 @@ custom_pts_should_springpad_create_trigs( s_lion_spot )
 }
 
 //if the number of players is 3 or less, once a ball is picked up, gives the ability to place a 2nd ball on a set of Trample Steams that already has a ball flinging from them for the Maxis Trample Steam step
-custom_pts_putdown_trigs_create_for_spot( s_lion_spot, player )
+pts_putdown_trigs_create_for_spot( s_lion_spot, player )
 {
 	if ( ( !isdefined( level.n_players_since_maxis_pts_start ) || level.n_players_since_maxis_pts_start >= 4 ) && ( isdefined( s_lion_spot.which_ball ) || isdefined( s_lion_spot.springpad_buddy ) && isdefined( s_lion_spot.springpad_buddy.which_ball ) ) )
 		return;
@@ -397,23 +382,4 @@ custom_pts_putdown_trigs_create_for_spot( s_lion_spot, player )
 
 	s_lion_spot.pts_putdown_trigs[player.characterindex] = t_place_ball;
 	level thread pts_putdown_trigs_springpad_delete_watcher( player, s_lion_spot );
-}
-
-onPlayerDisconnect( is_generator )
-{
-	if ( !is_generator )
-		level endon( "pts_1_springpads_placed" );
-
-	self waittill( "disconnect" );
-
-	if ( is_generator )
-	{
-		if ( isdefined( level.n_players_since_maxis_pts_start ) )
-			level.n_players_since_maxis_pts_start--;
-	}
-	else
-	{
-		if ( isdefined( level.n_players_since_rich_pts_start ) )
-			level.n_players_since_rich_pts_start--;
-	}
 }

--- a/zm_any_player_ee/scripts/zm/zm_highrise/die_rise_any_player_ee.gsc
+++ b/zm_any_player_ee/scripts/zm/zm_highrise/die_rise_any_player_ee.gsc
@@ -18,12 +18,15 @@ main()
 
 init()
 {
-	thread onPlayerConnect();
+	if ( maps\mp\zombies\_zm_sidequests::is_sidequest_allowed( "zclassic" ) )
+	{
+		thread onPlayerConnect();
 
-	if ( set_dvar_int_if_unset( "any_player_ee_highrise_nav", "1" ) )
-		thread buildNavTable();
+		if ( set_dvar_int_if_unset( "any_player_ee_highrise_nav", "1" ) )
+			thread buildNavTable();
 
-	thread handle_n_players_since_pts_start();
+		thread handle_n_players_since_pts_start();
+	}
 }
 
 onPlayerConnect()
@@ -56,6 +59,12 @@ buildNavTable()
 
 handle_n_players_since_pts_start()
 {
+	flag_wait( "start_zombie_round_logic" );
+	waittillframeend;
+
+	if ( level.maxcompleted && level.richcompleted )
+		return;
+
 	level waittill( "sq_slb_over" );
 
 	if ( !level.richcompleted )
@@ -200,7 +209,7 @@ custom_get_number_of_players( is_generator )
 {
 	n_players = getPlayers().size;
 
-	if ( isdefined( is_generator ) && !is_generator )
+	if ( isdefined( is_generator ) && !is_generator && isdefined( level.n_players_since_rich_pts_start ) )
 		n_players = level.n_players_since_rich_pts_start;
 
 	if ( n_players > 4 )
@@ -240,7 +249,7 @@ custom_place_ball_think( t_place_ball, s_lion_spot )
 	t_place_ball endon( "delete" );
 	t_place_ball waittill( "trigger" );
 
-	if ( level.n_players_since_maxis_pts_start > 3 )
+	if ( !isdefined( level.n_players_since_maxis_pts_start ) || level.n_players_since_maxis_pts_start > 3 )
 	{
 		pts_putdown_trigs_remove_for_spot( s_lion_spot );
 		pts_putdown_trigs_remove_for_spot( s_lion_spot.springpad_buddy );
@@ -260,7 +269,7 @@ custom_place_ball_think( t_place_ball, s_lion_spot )
 	s_lion_spot.springpad thread pts_springpad_fling( s_lion_spot.script_noteworthy, s_lion_spot.springpad_buddy.springpad );
 	self.t_putdown_ball delete();
 
-	if ( level.n_players_since_maxis_pts_start == 3 )
+	if ( isdefined( level.n_players_since_maxis_pts_start ) && level.n_players_since_maxis_pts_start == 3 )
 	{
 		foreach ( player in getPlayers() )
 		{
@@ -347,7 +356,7 @@ custom_pts_should_player_create_trigs( player )
 
 	foreach ( s_lion_spot in a_lion_spots )
 	{
-		if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) )
+		if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || ( isdefined( level.n_players_since_maxis_pts_start ) && ( level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) ) ) )
 			pts_putdown_trigs_create_for_spot( s_lion_spot, player );
 	}
 }
@@ -355,7 +364,7 @@ custom_pts_should_player_create_trigs( player )
 //on the Maxis side if the player is playing solo or 3p, once a player places a Trample Steam correctly, gives each player already carrying a ball the ability to place it without needing a Trample Steam on the opposite end. On 3p, this is executed if the Trample Steam is placed while there's already a ball flinging.
 custom_pts_should_springpad_create_trigs( s_lion_spot )
 {
-	if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) )
+	if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || ( isdefined( level.n_players_since_maxis_pts_start ) && ( level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) ) ) )
 	{
 		a_players = getplayers();
 
@@ -375,7 +384,7 @@ custom_pts_should_springpad_create_trigs( s_lion_spot )
 //if the number of players is 3 or less, once a ball is picked up, gives the ability to place a 2nd ball on a set of Trample Steams that already has a ball flinging from them for the Maxis Trample Steam step
 custom_pts_putdown_trigs_create_for_spot( s_lion_spot, player )
 {
-	if ( level.n_players_since_maxis_pts_start >= 4 && ( isdefined( s_lion_spot.which_ball ) || isdefined( s_lion_spot.springpad_buddy ) && isdefined( s_lion_spot.springpad_buddy.which_ball ) ) )
+	if ( ( !isdefined( level.n_players_since_maxis_pts_start ) || level.n_players_since_maxis_pts_start >= 4 ) && ( isdefined( s_lion_spot.which_ball ) || isdefined( s_lion_spot.springpad_buddy ) && isdefined( s_lion_spot.springpad_buddy.which_ball ) ) )
 		return;
 
 	t_place_ball = sq_pts_create_use_trigger( s_lion_spot.origin, 16, 70, &"ZM_HIGHRISE_SQ_PUTDOWN_BALL" );
@@ -398,7 +407,13 @@ onPlayerDisconnect( is_generator )
 	self waittill( "disconnect" );
 
 	if ( is_generator )
-		level.n_players_since_maxis_pts_start--;
+	{
+		if ( isdefined( level.n_players_since_maxis_pts_start ) )
+			level.n_players_since_maxis_pts_start--;
+	}
 	else
-		level.n_players_since_rich_pts_start--;
+	{
+		if ( isdefined( level.n_players_since_rich_pts_start ) )
+			level.n_players_since_rich_pts_start--;
+	}
 }

--- a/zm_any_player_ee/scripts/zm/zm_transit/tranzit_maxis_any_player_ee.gsc
+++ b/zm_any_player_ee/scripts/zm/zm_transit/tranzit_maxis_any_player_ee.gsc
@@ -10,7 +10,8 @@ main()
 
 init()
 {
-	thread onPlayerConnect();
+	if ( maps\mp\zombies\_zm_sidequests::is_sidequest_allowed( "zclassic" ) )
+		thread onPlayerConnect();
 }
 
 onPlayerConnect()


### PR DESCRIPTION
# Multiple Files
Added checks for the scripts to pass for some of the modifications to take effect

# buried_body_fix.gsc
Changed level.sq_tpo.times_searched to be set to 3 instead of be incremented to prevent potential bug of running multiples of the script

# nav_autocomplete.gsc
- Moved code to a separate function, and changed the map check from being done through an if statement to being done with switch
- Added a line to prevent runtime errors when incrementing unintialised stats of new players

# die_rise_any_player_ee.gsc
- Modified to accommodate for the game's behaviour of only checking Trample Steams of players who were present during the start of the Trample Steam steps
- Removed skip to Richtofen Trample Steam quotes
- Added a check in `place_ball_think` to prevent a runtime error
- Renamed function names to use the original names
- Moved some function definitions around