### PR TITLE
Version 1.4.4

### DIFF
--- a/crc32_checksums.txt
+++ b/crc32_checksums.txt
@@ -15,7 +15,8 @@ Patches\buried_any_player_ee-body_fix.gsc
 - 0x568DF4F4 (1.1.1)
 
 zm_any_player_ee\scripts\zm\Patches\die_rise_any_player_ee-no_reset.gsc
-- 0x1EF98907 (1.4.3–current)
+- 0x94B8A523 (1.4.4–current)
+- 0x1EF98907 (1.4.3)
 - 0x26933213
 - 0xA093404A
 - 0x52D977F1
@@ -68,7 +69,8 @@ zm_any_player_ee\scripts\zm\zm_buried\super_ee_any_player.gsc
 - 0x656E442D (1.1.1)
 
 zm_any_player_ee\scripts\zm\zm_highrise\die_rise_any_player_ee.gsc
-- 0xFB0503AE (1.4.3–current)
+- 0x754E5753 (1.4.4–current)
+- 0xFB0503AE (1.4.3)
 - 0x6692024B
 - 0x9818CD7E
 - 0x068307B0

--- a/crc32_checksums.txt
+++ b/crc32_checksums.txt
@@ -57,7 +57,8 @@ zm_any_player_ee\scripts\zm\zm_buried\buried_any_player_ee.gsc
 - 0xE12A442A (1.0–1.1)
 
 zm_any_player_ee\scripts\zm\zm_buried\super_ee_any_player.gsc
-- 0x9E9EA583 (1.4.3–current)
+- 0x42F2BE06 (1.4.4–current)
+- 0x9E9EA583 (1.4.3)
 - 0x517EC41C (1.4.0–1.4.2)
 - 0x55CABDD7 (1.3.1)
 - 0x7145975A (1.2.1–1.3.0)
@@ -88,7 +89,8 @@ zm_any_player_ee\scripts\zm\zm_highrise\die_rise_any_player_ee.gsc
 - 0xEF681238 (1.0)
 
 zm_any_player_ee\scripts\zm\zm_transit\tranzit_maxis_any_player_ee.gsc
-- 0xA54994AF (1.4.3–current)
+- 0xE46D1B7D (1.4.4–current)
+- 0xA54994AF (1.4.3)
 - 0x028E4FEF (1.4.1–1.4.2)
 - 0xEE8CDC79
 

--- a/crc32_checksums.txt
+++ b/crc32_checksums.txt
@@ -41,7 +41,8 @@ zm_any_player_ee\scripts\zm\Patches\nav_autocomplete.gsc
 - 0xEEFA8398 (after 1.2.1)
 
 zm_any_player_ee\scripts\zm\zm_buried\buried_any_player_ee.gsc
-- 0xA3A3B3F2 (1.4.3–current)
+- 0x83D47423 (1.4.4–current)
+- 0xA3A3B3F2 (1.4.3)
 - 0x4C2200B1 (1.4.2)
 - 0x009B30BD (1.4.1)
 - 0xAF03CA01 (1.4.0)

--- a/zm_any_player_ee/scripts/zm/Patches/die_rise_any_player_ee-no_reset.gsc
+++ b/zm_any_player_ee/scripts/zm/Patches/die_rise_any_player_ee-no_reset.gsc
@@ -351,7 +351,7 @@ pts_should_player_create_trigs( player )
 //on the Maxis side if the player is playing solo or 3p, once a player places a Trample Steam correctly, gives each player already carrying a ball the ability to place it without needing a Trample Steam on the opposite end. On 3p, this is executed if the Trample Steam is placed while there's already a ball flinging.
 pts_should_springpad_create_trigs( s_lion_spot )
 {
-	if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || ( isdefined( level.n_players_since_maxis_pts_start ) && ( level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) ) ) )
+	if ( isdefined( s_lion_spot.springpad ) && isdefined( s_lion_spot.springpad_buddy ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || ( isdefined( level.n_players_since_maxis_pts_start ) && ( level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) ) ) )
 	{
 		a_players = getplayers();
 

--- a/zm_any_player_ee/scripts/zm/zm_buried/buried_any_player_ee.gsc
+++ b/zm_any_player_ee/scripts/zm/zm_buried/buried_any_player_ee.gsc
@@ -2,16 +2,15 @@
 #include maps\mp\zm_buried_sq_ctw;
 #include maps\mp\zm_buried_sq_ip;
 #include maps\mp\zm_buried_sq_ows;
-#include maps\mp\zm_buried_sq_tpo;
 #include maps\mp\zombies\_zm_utility;
 
 main()
 {
-	replaceFunc( ::_are_all_players_in_time_bomb_volume, ::_are_all_players_in_time_bomb_volume_qol );
-	replaceFunc( ::ctw_max_start_wisp, ::custom_ctw_max_start_wisp );
-	replaceFunc( ::sq_bp_set_current_bulb, ::custom_sq_bp_set_current_bulb );
-	replaceFunc( ::ows_target_delete_timer, ::new_ows_target_delete_timer );
-	replaceFunc( ::ows_targets_start, ::new_ows_targets_start );
+	replaceFunc( maps\mp\zm_buried_sq_tpo::_are_all_players_in_time_bomb_volume, ::_are_all_players_in_time_bomb_volume );
+	replaceFunc( maps\mp\zm_buried_sq_ctw::ctw_max_start_wisp, ::ctw_max_start_wisp );
+	replaceFunc( maps\mp\zm_buried_sq_ip::sq_bp_set_current_bulb, ::sq_bp_set_current_bulb );
+	replaceFunc( maps\mp\zm_buried_sq_ows::ows_target_delete_timer, ::ows_target_delete_timer );
+	replaceFunc( maps\mp\zm_buried_sq_ows::ows_targets_start, ::ows_targets_start );
 }
 
 init()
@@ -36,7 +35,7 @@ display_mod_message()
 	self iPrintLn( "^2Any Player EE Mod ^5Buried" );
 }
 
-playertracker_onlast_step()
+targets_allowed_to_be_missed()
 {
 	switch ( getPlayers().size )
 	{
@@ -52,7 +51,7 @@ playertracker_onlast_step()
 	}
 }
 
-_are_all_players_in_time_bomb_volume_qol( e_volume )
+_are_all_players_in_time_bomb_volume( e_volume )
 {
 	n_required_players = 4;
 	a_players = get_players();
@@ -61,7 +60,7 @@ _are_all_players_in_time_bomb_volume_qol( e_volume )
 		n_required_players = a_players.size;
 
 /#
-	if ( getdvarint( #"_id_5256118F" ) > 0 )
+	if ( getdvarint( #"zm_buried_sq_debug" ) > 0 )
 		n_required_players = a_players.size;
 #/
 	n_players_in_position = 0;
@@ -76,7 +75,7 @@ _are_all_players_in_time_bomb_volume_qol( e_volume )
 	return b_all_in_valid_position;
 }
 
-custom_ctw_max_start_wisp()
+ctw_max_start_wisp()
 {
 	nd_start = getvehiclenode( level.m_sq_start_sign.target, "targetname" );
 	vh_wisp = spawnvehicle( "tag_origin", "wisp_ai", "heli_quadrotor2_zm", nd_start.origin, nd_start.angles );
@@ -116,14 +115,14 @@ buried_maxis_wisp()
 		for (;;)
 		{
 			if ( self.n_sq_energy <= 20 )
-				self.n_sq_energy += 20;
+				self.n_sq_energy += 10;
 
 			wait 1;
 		}
 	}
 }
 
-custom_sq_bp_set_current_bulb( str_tag )
+sq_bp_set_current_bulb( str_tag )
 {
 	level endon( "sq_bp_correct_button" );
 	level endon( "sq_bp_wrong_button" );
@@ -142,7 +141,7 @@ custom_sq_bp_set_current_bulb( str_tag )
 	}
 }
 
-new_ows_target_delete_timer()
+ows_target_delete_timer()
 {
 	self endon( "death" );
 	wait 4;
@@ -157,11 +156,11 @@ new_ows_target_delete_timer()
 #/
 }
 
-new_ows_targets_start()
+ows_targets_start()
 {
 	n_cur_second = 0;
 	flag_clear( "sq_ows_target_missed" );
-	playertracker_onlast_step();
+	targets_allowed_to_be_missed();
 	level thread sndsidequestowsmusic();
 	a_sign_spots = getstructarray( "otw_target_spot", "script_noteworthy" );
 

--- a/zm_any_player_ee/scripts/zm/zm_buried/super_ee_any_player.gsc
+++ b/zm_any_player_ee/scripts/zm/zm_buried/super_ee_any_player.gsc
@@ -4,7 +4,7 @@
 
 main()
 {
-	replaceFunc( ::sq_metagame, ::custom_sq_metagame );
+	replaceFunc( maps\mp\zm_buried_sq::sq_metagame, ::sq_metagame );
 }
 
 init()
@@ -29,7 +29,7 @@ display_mod_message()
 	self iPrintLn( "^2Any Player EE Mod ^5Super Easter Egg" );
 }
 
-custom_sq_metagame()
+sq_metagame()
 {
 	level endon( "sq_metagame_player_connected" );
 	flag_wait( "sq_intro_vo_done" );

--- a/zm_any_player_ee/scripts/zm/zm_highrise/die_rise_any_player_ee.gsc
+++ b/zm_any_player_ee/scripts/zm/zm_highrise/die_rise_any_player_ee.gsc
@@ -349,7 +349,7 @@ pts_should_player_create_trigs( player )
 //on the Maxis side if the player is playing solo or 3p, once a player places a Trample Steam correctly, gives each player already carrying a ball the ability to place it without needing a Trample Steam on the opposite end. On 3p, this is executed if the Trample Steam is placed while there's already a ball flinging.
 pts_should_springpad_create_trigs( s_lion_spot )
 {
-	if ( isdefined( s_lion_spot.springpad ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || ( isdefined( level.n_players_since_maxis_pts_start ) && ( level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) ) ) )
+	if ( isdefined( s_lion_spot.springpad ) && isdefined( s_lion_spot.springpad_buddy ) && ( isdefined( s_lion_spot.springpad_buddy.springpad ) || ( isdefined( level.n_players_since_maxis_pts_start ) && ( level.n_players_since_maxis_pts_start == 1 || ( level.n_players_since_maxis_pts_start == 3 && flag( "pts_2_generator_1_started" ) ) ) ) ) )
 	{
 		a_players = getplayers();
 

--- a/zm_any_player_ee/scripts/zm/zm_transit/tranzit_maxis_any_player_ee.gsc
+++ b/zm_any_player_ee/scripts/zm/zm_transit/tranzit_maxis_any_player_ee.gsc
@@ -4,8 +4,8 @@
 
 main()
 {
-	replaceFunc( ::maxis_sidequest_b, ::custom_maxis_sidequest_b );
-	replaceFunc( ::get_how_many_progressed_from, ::custom_get_how_many_progressed_from );
+	replaceFunc( maps\mp\zm_transit_sq::maxis_sidequest_b, ::maxis_sidequest_b );
+	replaceFunc( maps\mp\zm_transit_sq::get_how_many_progressed_from, ::get_how_many_progressed_from );
 }
 
 init()
@@ -30,7 +30,7 @@ display_mod_message()
 	self iPrintLn( "^2Any Player EE Mod ^5TranZit Maxis" );
 }
 
-custom_maxis_sidequest_b()
+maxis_sidequest_b()
 {
 	level endon( "power_on" );
 
@@ -57,7 +57,7 @@ custom_maxis_sidequest_b()
 	level thread maxis_sidequest_complete_check( "B_complete" );
 }
 
-custom_get_how_many_progressed_from( story, a, b )
+get_how_many_progressed_from( story, a, b )
 {
 	n_players = getPlayers().size;
 


### PR DESCRIPTION
# Multiple Files
Renamed functions

# die_rise_any_player_ee.gsc
Added additional check in pts_should_springpad_create_trigs to prevent prompt from appearing when a Trample Steam is placed on a zombie symbol on the Maxis Trample Steam step on 1p and 3p, which causes infinite loop if a ball is placed on it.

# buried_any_player_ee.gsc
- Resolved dvar hash
- Decreased Maxis wisp energy incrementation on 1p/2p so as to not exceed 30 energy (vanilla decreases it to 30 if it is more than that when near zombies)